### PR TITLE
Add GUI wizard and custom converter features

### DIFF
--- a/Application/FileConverter/ConversionJobs/ConversionJobFactory.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJobFactory.cs
@@ -6,6 +6,15 @@ namespace FileConverter.ConversionJobs
     {
         public static ConversionJob Create(ConversionPreset conversionPreset, string inputFilePath)
         {
+            if (!string.IsNullOrEmpty(conversionPreset.CustomConverterName))
+            {
+                var def = CustomConverters.CustomConverterManager.GetConverter(conversionPreset.CustomConverterName);
+                if (def != null)
+                {
+                    return new ConversionJob_Custom(conversionPreset, inputFilePath, def);
+                }
+            }
+
             string inputFileExtension = System.IO.Path.GetExtension(inputFilePath);
             inputFileExtension = inputFileExtension.ToLowerInvariant().Substring(1, inputFileExtension.Length - 1);
             if (inputFileExtension == "cda")

--- a/Application/FileConverter/ConversionJobs/ConversionJob_Custom.cs
+++ b/Application/FileConverter/ConversionJobs/ConversionJob_Custom.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using FileConverter.CustomConverters;
+
+namespace FileConverter.ConversionJobs
+{
+    public class ConversionJob_Custom : ConversionJob
+    {
+        private readonly CustomConverterDefinition definition;
+
+        public ConversionJob_Custom(ConversionPreset preset, string inputPath, CustomConverterDefinition def)
+            : base(preset, inputPath)
+        {
+            this.definition = def;
+        }
+
+        protected override void Convert()
+        {
+            string args = this.definition.Arguments ?? string.Empty;
+            args = args.Replace("{input}", this.InputFilePath).Replace("{output}", this.OutputFilePath);
+
+            if (this.definition.Variables != null)
+            {
+                foreach (var kv in this.definition.Variables)
+                {
+                    args = args.Replace("{" + kv.Key + "}", kv.Value ?? string.Empty);
+                }
+            }
+
+            if (this.definition.Options != null)
+            {
+                foreach (var opt in this.definition.Options)
+                {
+                    if (!opt.EvaluateCondition(this.Preset))
+                    {
+                        args = args.Replace("{" + opt.Name + "}", string.Empty);
+                        continue;
+                    }
+
+                    string value = this.Preset.GetSettingsValue(opt.Name) ?? string.Empty;
+                    args = args.Replace("{" + opt.Name + "}", value);
+                }
+            }
+
+            var psi = new ProcessStartInfo(this.definition.ProgramPath, args)
+            {
+                UseShellExecute = false,
+                RedirectStandardError = !this.definition.ShowProgram,
+                RedirectStandardOutput = !this.definition.ShowProgram,
+                CreateNoWindow = !this.definition.ShowProgram,
+            };
+
+            Process proc = Process.Start(psi);
+            string stdOut = null;
+            string stdErr = null;
+            if (!this.definition.ShowProgram)
+            {
+                stdOut = proc.StandardOutput.ReadToEnd();
+                stdErr = proc.StandardError.ReadToEnd();
+            }
+            proc.WaitForExit();
+
+            if (proc.ExitCode == 0 && System.IO.File.Exists(this.OutputFilePath))
+            {
+                if (!string.IsNullOrEmpty(this.definition.PostProcessCommand))
+                {
+                    try
+                    {
+                        var postPsi = new ProcessStartInfo(this.definition.PostProcessCommand)
+                        {
+                            UseShellExecute = false,
+                            CreateNoWindow = true,
+                        };
+                        var postProc = Process.Start(postPsi);
+                        postProc.WaitForExit();
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Diagnostics.Debug.Log($"Post process failed: {ex.Message}");
+                    }
+                }
+                this.OnConversionSucceed();
+            }
+            else
+            {
+                string errorMsg = $"External converter failed with code {proc.ExitCode}";
+                if (!string.IsNullOrEmpty(stdErr))
+                {
+                    errorMsg += ": " + stdErr.Trim();
+                }
+                this.ConversionFailed(errorMsg);
+            }
+        }
+    }
+}

--- a/Application/FileConverter/ConversionPreset/ConversionPreset.cs
+++ b/Application/FileConverter/ConversionPreset/ConversionPreset.cs
@@ -10,6 +10,7 @@ namespace FileConverter
     using CommunityToolkit.Mvvm.ComponentModel;
 
     using FileConverter.Controls;
+    using FileConverter.CustomConverters;
 
     [XmlRoot]
     [XmlType]
@@ -22,6 +23,7 @@ namespace FileConverter
         private InputPostConversionAction inputPostConversionAction;
         private ConversionSettings settings = new ConversionSettings();
         private string outputFileNameTemplate;
+        private string customConverterName;
 
         public ConversionPreset()
         {
@@ -139,6 +141,28 @@ namespace FileConverter
         {
             get;
             set;
+        }
+
+        [XmlAttribute]
+        public string CustomConverterName
+        {
+            get => this.customConverterName;
+
+            set
+            {
+                this.customConverterName = value;
+                this.OnPropertyChanged();
+                this.OnPropertyChanged(nameof(this.CustomConverterDefinition));
+            }
+        }
+
+        [XmlIgnore]
+        public CustomConverters.CustomConverterDefinition CustomConverterDefinition
+        {
+            get
+            {
+                return CustomConverters.CustomConverterManager.GetConverter(this.customConverterName);
+            }
         }
 
         [XmlElement]
@@ -321,7 +345,14 @@ namespace FileConverter
 
         public string GenerateOutputFilePath(string inputFilePath, int numberIndex, int numberMax)
         {
-            return PathHelpers.GenerateFilePathFromTemplate(inputFilePath, this.OutputType, this.OutputFileNameTemplate, numberIndex, numberMax);
+            string customExtension = null;
+            if (!string.IsNullOrEmpty(this.CustomConverterName))
+            {
+                var def = CustomConverterManager.GetConverter(this.CustomConverterName);
+                customExtension = def?.OutputExtension;
+            }
+
+            return PathHelpers.GenerateFilePathFromTemplate(inputFilePath, this.OutputType, this.OutputFileNameTemplate, numberIndex, numberMax, customExtension);
         }
 
         public void SetSettingsValue(string settingsKey, string value)

--- a/Application/FileConverter/CustomConverters/CustomConverterDefinition.cs
+++ b/Application/FileConverter/CustomConverters/CustomConverterDefinition.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace FileConverter.CustomConverters
+{
+    [XmlRoot("CustomConverter")]
+    public class CustomConverterDefinition : IXmlSerializable
+    {
+        [XmlElement("Name")]
+        public string Name { get; set; }
+
+        [XmlArray("Extensions")]
+        [XmlArrayItem("Extension")]
+        public string[] Extensions { get; set; }
+
+        [XmlElement("OutputExtension")]
+        public string OutputExtension { get; set; }
+
+        [XmlElement("Program")]
+        public string ProgramPath { get; set; }
+
+        [XmlElement("Arguments")]
+        public string Arguments { get; set; }
+
+        [XmlElement("OutputTemplate")]
+        public string OutputTemplate { get; set; }
+
+        [XmlElement("Icon")]
+        public string IconPath { get; set; }
+
+        [XmlIgnore]
+        public string IconAbsolutePath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(this.IconPath))
+                {
+                    return null;
+                }
+
+                string directory = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "CustomConverters");
+                return System.IO.Path.Combine(directory, this.IconPath);
+            }
+        }
+
+        [XmlElement("PostProcessCommand")]
+        public string PostProcessCommand { get; set; }
+
+        [XmlElement("MultiFileAtOnce")]
+        public bool MultiFileAtOnce { get; set; }
+
+        [XmlElement("ShowProgram")]
+        public bool ShowProgram { get; set; } = true;
+
+        [XmlElement("PostAction")]
+        public InputPostConversionAction PostAction { get; set; }
+
+        [XmlAnyElement]
+        public XmlElement[] CustomOptions { get; set; }
+
+        [XmlIgnore]
+        public Dictionary<string, string> Variables { get; private set; } = new Dictionary<string, string>();
+
+        [XmlIgnore]
+        public List<CustomConverterOptionDefinition> Options { get; private set; } = new List<CustomConverterOptionDefinition>();
+
+        public void OnDeserializationComplete()
+        {
+            if (this.CustomOptions != null)
+            {
+                foreach (XmlElement element in this.CustomOptions)
+                {
+                    if (string.Equals(element.Name, "Variable", System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        string name = element.GetAttribute("name");
+                        string value = element.GetAttribute("value");
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            this.Variables[name] = value;
+                        }
+                    }
+                    else
+                    {
+                        this.Options.Add(CustomConverterOptionDefinition.FromXml(element));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Application/FileConverter/CustomConverters/CustomConverterManager.cs
+++ b/Application/FileConverter/CustomConverters/CustomConverterManager.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+
+namespace FileConverter.CustomConverters
+{
+    public static class CustomConverterManager
+    {
+        private static Dictionary<string, CustomConverterDefinition> converters;
+        private static FileSystemWatcher watcher;
+
+        public static event Action ConvertersUpdated;
+
+        public static IEnumerable<CustomConverterDefinition> Converters
+        {
+            get
+            {
+                EnsureLoaded();
+                return converters.Values;
+            }
+        }
+
+        public static CustomConverterDefinition GetConverter(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
+            EnsureLoaded();
+            converters.TryGetValue(name, out var def);
+            return def;
+        }
+
+        private static void EnsureLoaded()
+        {
+            if (converters != null)
+            {
+                return;
+            }
+
+            converters = new Dictionary<string, CustomConverterDefinition>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                string directory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "CustomConverters");
+                if (!Directory.Exists(directory))
+                {
+                    return;
+                }
+
+                foreach (string file in Directory.GetFiles(directory, "*.xml"))
+                {
+                    try
+                    {
+                        FileConverter.XmlHelpers.LoadFromFile("CustomConverter", file, out CustomConverterDefinition def);
+                        if (!string.IsNullOrEmpty(def?.Name))
+                        {
+                            converters[def.Name] = def;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Diagnostics.Debug.Log($"Failed to load custom converter {file}: {ex.Message}");
+                    }
+                }
+
+                EnsureWatcher(directory);
+            }
+            catch (Exception ex)
+            {
+                Diagnostics.Debug.Log($"Failed to load custom converters: {ex.Message}");
+            }
+        }
+
+        private static void EnsureWatcher(string directory)
+        {
+            if (watcher != null)
+            {
+                return;
+            }
+
+            watcher = new FileSystemWatcher(directory, "*.xml");
+            watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime;
+            watcher.Changed += OnConvertersChanged;
+            watcher.Created += OnConvertersChanged;
+            watcher.Deleted += OnConvertersChanged;
+            watcher.Renamed += OnConvertersChanged;
+            watcher.EnableRaisingEvents = true;
+        }
+
+        private static void OnConvertersChanged(object sender, FileSystemEventArgs e)
+        {
+            converters = null;
+            ConvertersUpdated?.Invoke();
+        }
+
+        public static void SaveConverter(CustomConverterDefinition def)
+        {
+            if (def == null || string.IsNullOrEmpty(def.Name))
+            {
+                return;
+            }
+
+            EnsureLoaded();
+            string directory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "CustomConverters");
+            Directory.CreateDirectory(directory);
+            string file = Path.Combine(directory, def.Name + ".xml");
+            XmlHelpers.SaveToFile("CustomConverter", file, def);
+            converters[def.Name] = def;
+        }
+
+        public static void RemoveConverter(string name)
+        {
+            EnsureLoaded();
+            string directory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "CustomConverters");
+            string file = Path.Combine(directory, name + ".xml");
+            if (File.Exists(file))
+            {
+                File.Delete(file);
+            }
+
+            converters.Remove(name);
+        }
+
+        public static void Export(string name, string destination)
+        {
+            var def = GetConverter(name);
+            if (def == null)
+            {
+                return;
+            }
+
+            string directory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "CustomConverters");
+            string xmlPath = Path.Combine(directory, name + ".xml");
+
+            using (var zip = System.IO.Compression.ZipFile.Open(destination, System.IO.Compression.ZipArchiveMode.Create))
+            {
+                if (File.Exists(xmlPath))
+                {
+                    zip.CreateEntryFromFile(xmlPath, name + ".xml");
+                }
+
+                if (!string.IsNullOrEmpty(def.IconPath))
+                {
+                    string icon = Path.Combine(directory, def.IconPath);
+                    if (File.Exists(icon))
+                    {
+                        zip.CreateEntryFromFile(icon, Path.GetFileName(def.IconPath));
+                    }
+                }
+            }
+        }
+
+        public static void Import(string package)
+        {
+            string directory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "CustomConverters");
+            Directory.CreateDirectory(directory);
+            System.IO.Compression.ZipFile.ExtractToDirectory(package, directory, true);
+            converters = null;
+            ConvertersUpdated?.Invoke();
+        }
+    }
+}

--- a/Application/FileConverter/CustomConverters/CustomConverterOptionDefinition.cs
+++ b/Application/FileConverter/CustomConverters/CustomConverterOptionDefinition.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Serialization;
+using FileConverter.Properties;
+
+namespace FileConverter.CustomConverters
+{
+    public class CustomConverterOptionEntry
+    {
+        [XmlAttribute("text")]
+        public string Text { get; set; }
+
+        [XmlAttribute("value")]
+        public string Value { get; set; }
+    }
+
+    public class CustomConverterOptionDefinition
+    {
+        [XmlIgnore]
+        public string ElementName { get; set; }
+
+        [XmlAttribute("name")]
+        public string Name { get; set; }
+
+        [XmlAttribute("control")]
+        public string ControlType { get; set; }
+
+        [XmlAttribute("scale")]
+        public string Scale { get; set; }
+
+        [XmlAttribute("value-type")]
+        public string ValueType { get; set; }
+
+        [XmlAttribute("checked-value")]
+        public string CheckedValue { get; set; }
+
+        [XmlAttribute("unchecked-value")]
+        public string UncheckedValue { get; set; }
+
+        [XmlAttribute("group")]
+        public string Group { get; set; }
+
+        [XmlAttribute("category")]
+        public string Category { get; set; }
+
+        [XmlAttribute("resource-key")]
+        public string ResourceKey { get; set; }
+
+        [XmlAttribute("condition")]
+        public string Condition { get; set; }
+
+        [XmlAttribute("value")]
+        public string DefaultValue { get; set; }
+
+        [XmlIgnore]
+        public string DisplayName
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.ResourceKey))
+                {
+                    string localized = Properties.Resources.ResourceManager.GetString(this.ResourceKey);
+                    return string.IsNullOrEmpty(localized) ? this.Name : localized;
+                }
+
+                return this.Name;
+            }
+        }
+
+        [XmlElement("Item")]
+        public List<CustomConverterOptionEntry> Items { get; set; } = new List<CustomConverterOptionEntry>();
+
+        public bool EvaluateCondition(ConversionPreset preset)
+        {
+            if (string.IsNullOrEmpty(this.Condition) || preset == null)
+            {
+                return true;
+            }
+
+            string condition = this.Condition;
+            bool notEquals = condition.Contains("!=");
+            string[] parts = condition.Split(notEquals ? new[] { "!=" } : new[] { "=" }, 2, StringSplitOptions.None);
+            if (parts.Length != 2)
+            {
+                return true;
+            }
+
+            string value = preset.GetSettingsValue(parts[0].Trim()) ?? string.Empty;
+            string expected = parts[1].Trim();
+            bool equals = string.Equals(value, expected, StringComparison.OrdinalIgnoreCase);
+            return notEquals ? !equals : equals;
+        }
+
+        internal static CustomConverterOptionDefinition FromXml(XmlElement element)
+        {
+            var opt = new CustomConverterOptionDefinition
+            {
+                ElementName = element.Name,
+                Name = element.GetAttribute("name"),
+                ControlType = element.GetAttribute("control"),
+                Scale = element.GetAttribute("scale"),
+                ValueType = element.GetAttribute("value-type"),
+                CheckedValue = element.GetAttribute("checked-value"),
+                UncheckedValue = element.GetAttribute("unchecked-value"),
+                Group = element.GetAttribute("group"),
+                Category = element.GetAttribute("category"),
+                ResourceKey = element.GetAttribute("resource-key"),
+                Condition = element.GetAttribute("condition"),
+                DefaultValue = element.GetAttribute("value")
+            };
+
+            foreach (XmlNode child in element.ChildNodes)
+            {
+                if (child is XmlElement childElement)
+                {
+                    if (string.Equals(childElement.Name, "Item", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(childElement.Name, "Entry", StringComparison.OrdinalIgnoreCase))
+                    {
+                        opt.Items.Add(new CustomConverterOptionEntry
+                        {
+                            Text = childElement.InnerText,
+                            Value = childElement.GetAttribute("value")
+                        });
+                    }
+                }
+            }
+
+            return opt;
+        }
+    }
+}

--- a/Application/FileConverter/CustomConverters/sample.xml
+++ b/Application/FileConverter/CustomConverters/sample.xml
@@ -1,0 +1,17 @@
+<CustomConverter>
+    <Name>Sample Converter</Name>
+    <Extensions>
+        <Extension>abc</Extension>
+    </Extensions>
+    <OutputExtension>xyz</OutputExtension>
+    <Program>converter.exe</Program>
+    <Arguments>"{input}" "{output}"</Arguments>
+    <OutputTemplate>(p)(f)_converted</OutputTemplate>
+    <Icon>icon.png</Icon>
+    <PostProcessCommand>after.bat</PostProcessCommand>
+    <MultiFileAtOnce>false</MultiFileAtOnce>
+    <ShowProgram>false</ShowProgram>
+    <PostAction>None</PostAction>
+    <Variable name="quality" value="5" />
+    <Quality name="quality" control="slider" scale="10" value-type="int" value="5" />
+</CustomConverter>

--- a/Application/FileConverter/FileConverter.csproj
+++ b/Application/FileConverter/FileConverter.csproj
@@ -123,6 +123,10 @@
     <Compile Include="ConversionJobs\ConversionJob_Excel.cs" />
     <Compile Include="ConversionJobs\ConversionJob_Word.cs" />
     <Compile Include="ConversionJobs\ConversionJob_ImageMagick.cs" />
+    <Compile Include="ConversionJobs\ConversionJob_Custom.cs" />
+    <Compile Include="CustomConverters\CustomConverterDefinition.cs" />
+    <Compile Include="CustomConverters\CustomConverterOptionDefinition.cs" />
+    <Compile Include="CustomConverters\CustomConverterManager.cs" />
     <Compile Include="ConversionJobs\ConversionState.cs" />
     <Compile Include="ConversionJobs\VideoEncodingSpeed.cs" />
     <Compile Include="ConversionPreset\ConversionSettingsOverride.cs" />
@@ -176,6 +180,8 @@
     <Compile Include="ValueConverters\Generic\FormatStringConverter.cs" />
     <Compile Include="ValueConverters\Generic\ValueToString.cs" />
     <Compile Include="ValueConverters\Generic\StringToValueType.cs" />
+    <Compile Include="ValueConverters\CustomOptionValueConverter.cs" />
+    <Compile Include="ValueConverters\OptionVisibilityConverter.cs" />
     <Compile Include="ValueConverters\InputTypesToBool.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="ValueConverters\OutputTypeToVisibility.cs" />
@@ -195,6 +201,18 @@
     </Compile>
     <Compile Include="Views\DiagnosticsWindow.xaml.cs">
       <DependentUpon>DiagnosticsWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ViewModels\CustomConverterWizardViewModel.cs" />
+    <Compile Include="Views\CustomConverterWizard.xaml.cs">
+      <DependentUpon>CustomConverterWizard.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ViewModels\CustomOptionEditorViewModel.cs" />
+    <Compile Include="ViewModels\ManageCustomConvertersViewModel.cs" />
+    <Compile Include="Views\CustomOptionEditor.xaml.cs">
+      <DependentUpon>CustomOptionEditor.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\ManageCustomConvertersWindow.xaml.cs">
+      <DependentUpon>ManageCustomConvertersWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="ViewModels\InputExtension.cs" />
     <Compile Include="ViewModels\InputExtensionCategory.cs" />
@@ -251,6 +269,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\SettingsWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\CustomOptionEditor.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\ManageCustomConvertersWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\CustomConverterWizard.xaml"
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Application/FileConverter/Helpers.cs
+++ b/Application/FileConverter/Helpers.cs
@@ -224,6 +224,9 @@ namespace FileConverter
                 case OutputType.Pdf:
                     return category == InputCategoryNames.Image || category == InputCategoryNames.Document;
 
+                case OutputType.Custom:
+                    return true;
+
                 default:
                     return false;
             }

--- a/Application/FileConverter/OutputType.cs
+++ b/Application/FileConverter/OutputType.cs
@@ -22,5 +22,7 @@ namespace FileConverter
         Wav,
         Webm,
         Webp,
+
+        Custom,
     }
 }

--- a/Application/FileConverter/PathHelpers.cs
+++ b/Application/FileConverter/PathHelpers.cs
@@ -139,7 +139,7 @@ namespace FileConverter
             return true;
         }
 
-        public static string GenerateFilePathFromTemplate(string inputFilePath, OutputType outputFileExtension, string outputFilePathTemplate, int numberIndex, int numberMax)
+        public static string GenerateFilePathFromTemplate(string inputFilePath, OutputType outputFileExtension, string outputFilePathTemplate, int numberIndex, int numberMax, string customOutputExtension = null)
         {
             if (string.IsNullOrEmpty(inputFilePath))
             {
@@ -148,7 +148,7 @@ namespace FileConverter
 
             string inputExtension = System.IO.Path.GetExtension(inputFilePath).Substring(1);
             string inputPathWithoutExtension = inputFilePath.Substring(0, inputFilePath.Length - inputExtension.Length - 1);
-            string outputExtension = outputFileExtension.ToString().ToLowerInvariant();
+            string outputExtension = customOutputExtension ?? outputFileExtension.ToString().ToLowerInvariant();
 
             if (string.IsNullOrEmpty(outputFilePathTemplate))
             {

--- a/Application/FileConverter/Properties/Resources.Designer.cs
+++ b/Application/FileConverter/Properties/Resources.Designer.cs
@@ -95,6 +95,24 @@ namespace FileConverter.Properties {
                 return ResourceManager.GetString("AddNewPreset", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to New custom converter.
+        /// </summary>
+        public static string AddCustomConverter {
+            get {
+                return ResourceManager.GetString("AddCustomConverter", resourceCulture);
+            }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Manage custom converters.
+        /// </summary>
+        public static string ManageCustomConverters {
+            get {
+                return ResourceManager.GetString("ManageCustomConverters", resourceCulture);
+            }
+        }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Advanced mode.

--- a/Application/FileConverter/Properties/Resources.en.resx
+++ b/Application/FileConverter/Properties/Resources.en.resx
@@ -129,6 +129,12 @@
   <data name="AddNewPreset" xml:space="preserve">
     <value>New preset</value>
   </data>
+  <data name="AddCustomConverter" xml:space="preserve">
+    <value>New custom converter</value>
+  </data>
+  <data name="ManageCustomConverters" xml:space="preserve">
+    <value>Manage custom converters</value>
+  </data>
   <data name="Application" xml:space="preserve">
     <value>Application</value>
   </data>

--- a/Application/FileConverter/Properties/Resources.resx
+++ b/Application/FileConverter/Properties/Resources.resx
@@ -129,6 +129,12 @@
   <data name="AddNewPreset" xml:space="preserve">
     <value>New preset</value>
   </data>
+  <data name="AddCustomConverter" xml:space="preserve">
+    <value>New custom converter</value>
+  </data>
+  <data name="ManageCustomConverters" xml:space="preserve">
+    <value>Manage custom converters</value>
+  </data>
   <data name="Application" xml:space="preserve">
     <value>Application</value>
   </data>

--- a/Application/FileConverter/Services/SettingsService.cs
+++ b/Application/FileConverter/Services/SettingsService.cs
@@ -20,6 +20,8 @@ namespace FileConverter.Services
             // Load settigns.
             Debug.Log("Load settings...");
             this.Settings = this.Load();
+
+            CustomConverters.CustomConverterManager.ConvertersUpdated += this.OnConvertersUpdated;
         }
 
         public Settings Settings
@@ -180,6 +182,39 @@ namespace FileConverter.Services
                 }
             }
 
+            if (settings != null)
+            {
+                foreach (var def in CustomConverters.CustomConverterManager.Converters)
+                {
+                    bool exists = false;
+                    foreach (var preset in settings.ConversionPresets)
+                    {
+                        if (preset.CustomConverterName == def.Name)
+                        {
+                            exists = true;
+                            break;
+                        }
+                    }
+
+                    if (!exists)
+                    {
+                        var preset = new ConversionPreset(def.Name, OutputType.Custom, def.Extensions);
+                        preset.CustomConverterName = def.Name;
+                        preset.InputPostConversionAction = def.PostAction;
+                        foreach (var opt in def.Options)
+                        {
+                            string defaultValue = opt.DefaultValue;
+                            if (string.IsNullOrEmpty(defaultValue) && opt.Items.Count > 0)
+                            {
+                                defaultValue = opt.Items[0].Value;
+                            }
+                            preset.InitializeSettingsValue(opt.Name, defaultValue ?? string.Empty, true);
+                        }
+                        settings.ConversionPresets.Add(preset);
+                    }
+                }
+            }
+
             return settings;
         }
 
@@ -200,6 +235,50 @@ namespace FileConverter.Services
             File.Delete(this.UserSettingsTemporaryFilePath);
 
             return true;
+        }
+
+        private void OnConvertersUpdated()
+        {
+            this.UpdateCustomPresets();
+        }
+
+        private void UpdateCustomPresets()
+        {
+            if (this.Settings == null || this.Settings.ConversionPresets == null)
+            {
+                return;
+            }
+
+            foreach (var def in CustomConverters.CustomConverterManager.Converters)
+            {
+                bool exists = false;
+                foreach (var preset in this.Settings.ConversionPresets)
+                {
+                    if (preset.CustomConverterName == def.Name)
+                    {
+                        exists = true;
+                        break;
+                    }
+                }
+
+                if (!exists)
+                {
+                    var preset = new ConversionPreset(def.Name, OutputType.Custom, def.Extensions);
+                    preset.CustomConverterName = def.Name;
+                    preset.InputPostConversionAction = def.PostAction;
+                    preset.OutputFileNameTemplate = def.OutputTemplate;
+                    foreach (var opt in def.Options)
+                    {
+                        string defaultValue = opt.DefaultValue;
+                        if (string.IsNullOrEmpty(defaultValue) && opt.Items.Count > 0)
+                        {
+                            defaultValue = opt.Items[0].Value;
+                        }
+                        preset.InitializeSettingsValue(opt.Name, defaultValue ?? string.Empty, true);
+                    }
+                    this.Settings.ConversionPresets.Add(preset);
+                }
+            }
         }
     }
 }

--- a/Application/FileConverter/ValueConverters/CustomOptionValueConverter.cs
+++ b/Application/FileConverter/ValueConverters/CustomOptionValueConverter.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using FileConverter.CustomConverters;
+using FileConverter.ConversionPreset;
+
+namespace FileConverter.ValueConverters
+{
+    public class CustomOptionValueConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is IConversionSettings settings) || !(parameter is CustomConverterOptionDefinition opt))
+            {
+                return null;
+            }
+
+            if (!settings.TryGetValue(opt.Name, out string str))
+            {
+                str = opt.DefaultValue;
+            }
+
+            switch (opt.ControlType?.ToLowerInvariant())
+            {
+                case "checkbox":
+                    return string.Equals(str, opt.CheckedValue, StringComparison.OrdinalIgnoreCase);
+                case "slider":
+                case "textbox":
+                case "dropdown":
+                case "radio":
+                default:
+                    {
+                        if (string.IsNullOrEmpty(opt.ValueType))
+                        {
+                            return str;
+                        }
+
+                        Type type = Type.GetType(opt.ValueType) ?? typeof(string);
+                        return System.Convert.ChangeType(str, type, culture);
+                    }
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(parameter is CustomConverterOptionDefinition opt))
+            {
+                return null;
+            }
+
+            string result;
+            if (opt.ControlType?.ToLowerInvariant() == "checkbox")
+            {
+                bool b = value is bool bl && bl;
+                result = b ? opt.CheckedValue : opt.UncheckedValue;
+            }
+            else
+            {
+                result = System.Convert.ToString(value, culture);
+            }
+
+            return new ConversionSettingsOverride(opt.Name, result);
+        }
+    }
+}

--- a/Application/FileConverter/ValueConverters/FileNameConverter.cs
+++ b/Application/FileConverter/ValueConverters/FileNameConverter.cs
@@ -24,7 +24,7 @@ namespace FileConverter.ValueConverters
             OutputType outputFileExtension = (OutputType)values[1];
             string outputFileTemplate = values[2] as string;
 
-            return PathHelpers.GenerateFilePathFromTemplate(inputFilePath, outputFileExtension, outputFileTemplate, 1, 3);
+            return PathHelpers.GenerateFilePathFromTemplate(inputFilePath, outputFileExtension, outputFileTemplate, 1, 3, null);
         }
 
         public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)

--- a/Application/FileConverter/ValueConverters/OptionVisibilityConverter.cs
+++ b/Application/FileConverter/ValueConverters/OptionVisibilityConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using FileConverter.ConversionPreset;
+using FileConverter.CustomConverters;
+
+namespace FileConverter.ValueConverters
+{
+    public class OptionVisibilityConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length < 2)
+            {
+                return Visibility.Visible;
+            }
+
+            var option = values[0] as CustomConverterOptionDefinition;
+            var preset = values[1] as ConversionPreset.ConversionPreset;
+            if (option == null || preset == null)
+            {
+                return Visibility.Visible;
+            }
+
+            return option.EvaluateCondition(preset) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Application/FileConverter/ViewModels/CustomConverterWizardViewModel.cs
+++ b/Application/FileConverter/ViewModels/CustomConverterWizardViewModel.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.IO;
+using System.Windows;
+using System.Windows.Input;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FileConverter.CustomConverters;
+using FileConverter.Views;
+
+namespace FileConverter.ViewModels
+{
+    public class CustomConverterWizardViewModel : ObservableObject
+    {
+        private int stepIndex;
+        private string name;
+        private string extensionsText;
+        private string outputExtension;
+        private string programPath;
+        private string arguments;
+        private string outputTemplate;
+        private string iconPath;
+        private string postProcessCommand;
+        private bool multiFileAtOnce;
+        private bool showProgram = true;
+        private InputPostConversionAction postAction;
+
+        private ObservableCollection<CustomConverterOptionDefinition> options = new ObservableCollection<CustomConverterOptionDefinition>();
+        private CustomConverterOptionDefinition selectedOption;
+
+        public CustomConverterWizardViewModel()
+        {
+            this.NextCommand = new RelayCommand(this.NextStep, this.CanNext);
+            this.BackCommand = new RelayCommand(this.PreviousStep, this.CanBack);
+            this.FinishCommand = new RelayCommand<Window>(this.Finish, this.CanFinish);
+            this.AddOptionCommand = new RelayCommand(this.AddOption);
+            this.EditOptionCommand = new RelayCommand(this.EditCurrentOption, () => this.SelectedOption != null);
+            this.RemoveOptionCommand = new RelayCommand(this.RemoveCurrentOption, () => this.SelectedOption != null);
+        }
+
+        public ICommand NextCommand { get; }
+        public ICommand BackCommand { get; }
+        public ICommand FinishCommand { get; }
+        public ICommand AddOptionCommand { get; }
+        public ICommand EditOptionCommand { get; }
+        public ICommand RemoveOptionCommand { get; }
+
+        public int StepIndex
+        {
+            get => this.stepIndex;
+            set => this.SetProperty(ref this.stepIndex, value);
+        }
+
+        public string Name
+        {
+            get => this.name;
+            set => this.SetProperty(ref this.name, value);
+        }
+
+        public string ExtensionsText
+        {
+            get => this.extensionsText;
+            set => this.SetProperty(ref this.extensionsText, value);
+        }
+
+        public string OutputExtension
+        {
+            get => this.outputExtension;
+            set => this.SetProperty(ref this.outputExtension, value);
+        }
+
+        public string ProgramPath
+        {
+            get => this.programPath;
+            set => this.SetProperty(ref this.programPath, value);
+        }
+
+        public string Arguments
+        {
+            get => this.arguments;
+            set => this.SetProperty(ref this.arguments, value);
+        }
+
+        public string OutputTemplate
+        {
+            get => this.outputTemplate;
+            set => this.SetProperty(ref this.outputTemplate, value);
+        }
+
+        public string IconPath
+        {
+            get => this.iconPath;
+            set => this.SetProperty(ref this.iconPath, value);
+        }
+
+        public string PostProcessCommand
+        {
+            get => this.postProcessCommand;
+            set => this.SetProperty(ref this.postProcessCommand, value);
+        }
+
+        public bool MultiFileAtOnce
+        {
+            get => this.multiFileAtOnce;
+            set => this.SetProperty(ref this.multiFileAtOnce, value);
+        }
+
+        public bool ShowProgram
+        {
+            get => this.showProgram;
+            set => this.SetProperty(ref this.showProgram, value);
+        }
+
+        public InputPostConversionAction PostAction
+        {
+            get => this.postAction;
+            set => this.SetProperty(ref this.postAction, value);
+        }
+
+        public ObservableCollection<CustomConverterOptionDefinition> Options => this.options;
+
+        public CustomConverterOptionDefinition SelectedOption
+        {
+            get => this.selectedOption;
+            set
+            {
+                if (this.SetProperty(ref this.selectedOption, value))
+                {
+                    (this.RemoveOptionCommand as RelayCommand)?.NotifyCanExecuteChanged();
+                    (this.EditOptionCommand as RelayCommand)?.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+        public CustomConverterDefinition Definition { get; private set; }
+
+        private bool CanNext()
+        {
+            if (this.StepIndex == 0)
+            {
+                return !string.IsNullOrWhiteSpace(this.Name) &&
+                    !string.IsNullOrWhiteSpace(this.ExtensionsText) &&
+                    !string.IsNullOrWhiteSpace(this.OutputExtension);
+            }
+
+            if (this.StepIndex == 1)
+            {
+                return !string.IsNullOrWhiteSpace(this.ProgramPath);
+            }
+
+            return false;
+        }
+
+        private void NextStep()
+        {
+            if (this.StepIndex < 2)
+            {
+                this.StepIndex++;
+            }
+        }
+
+        private bool CanBack() => this.StepIndex > 0;
+
+        private void PreviousStep()
+        {
+            if (this.StepIndex > 0)
+            {
+                this.StepIndex--;
+            }
+        }
+
+        private bool CanFinish(Window _) =>
+            this.StepIndex == 2;
+
+        private void Finish(Window window)
+        {
+            var exts = this.ExtensionsText?.Split(new[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(e => e.Trim().TrimStart('.')).ToArray();
+
+            if (exts == null || exts.Length == 0 || exts.Any(e => e.Any(ch => !char.IsLetterOrDigit(ch))))
+            {
+                MessageBox.Show("Invalid extensions.");
+                return;
+            }
+
+            if (!File.Exists(this.ProgramPath))
+            {
+                MessageBox.Show("Program file does not exist.");
+                return;
+            }
+
+            this.Definition = new CustomConverterDefinition
+            {
+                Name = this.Name,
+                Extensions = exts,
+                OutputExtension = this.OutputExtension?.TrimStart('.'),
+                ProgramPath = this.ProgramPath,
+                Arguments = this.Arguments,
+                MultiFileAtOnce = this.MultiFileAtOnce,
+                ShowProgram = this.ShowProgram,
+                PostAction = this.PostAction,
+                OutputTemplate = this.OutputTemplate,
+                IconPath = this.IconPath,
+                PostProcessCommand = this.PostProcessCommand,
+            };
+            foreach (var opt in this.options)
+            {
+                this.Definition.Options.Add(opt);
+            }
+            if (window != null)
+            {
+                window.DialogResult = true;
+                window.Close();
+            }
+        }
+
+        private void AddOption()
+        {
+            this.options.Add(new CustomConverterOptionDefinition { ElementName = "Option" });
+        }
+
+        private void RemoveOption(CustomConverterOptionDefinition option)
+        {
+            if (option != null)
+            {
+                this.options.Remove(option);
+            }
+        }
+
+        private void EditCurrentOption()
+        {
+            if (this.SelectedOption == null) return;
+            var vm = new CustomOptionEditorViewModel(this.SelectedOption);
+            var wnd = new Views.CustomOptionEditor { DataContext = vm };
+            wnd.ShowDialog();
+        }
+
+        private void RemoveCurrentOption()
+        {
+            if (this.SelectedOption != null)
+            {
+                this.options.Remove(this.SelectedOption);
+            }
+        }
+    }
+}

--- a/Application/FileConverter/ViewModels/CustomOptionEditorViewModel.cs
+++ b/Application/FileConverter/ViewModels/CustomOptionEditorViewModel.cs
@@ -1,0 +1,203 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FileConverter.CustomConverters;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace FileConverter.ViewModels
+{
+    public class CustomOptionEditorViewModel : ObservableObject
+    {
+        private readonly CustomConverterOptionDefinition option;
+        public CustomOptionEditorViewModel(CustomConverterOptionDefinition option)
+        {
+            this.option = option;
+            this.OkCommand = new RelayCommand<Window>(w => { if (w != null) { w.DialogResult = true; w.Close(); } });
+        }
+
+        public RelayCommand<Window> OkCommand { get; }
+
+        public string ElementName
+        {
+            get => this.option.ElementName;
+            set
+            {
+                if (this.option.ElementName != value)
+                {
+                    this.option.ElementName = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Name
+        {
+            get => this.option.Name;
+            set
+            {
+                if (this.option.Name != value)
+                {
+                    this.option.Name = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string ControlType
+        {
+            get => this.option.ControlType;
+            set
+            {
+                if (this.option.ControlType != value)
+                {
+                    this.option.ControlType = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Scale
+        {
+            get => this.option.Scale;
+            set
+            {
+                if (this.option.Scale != value)
+                {
+                    this.option.Scale = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string ValueType
+        {
+            get => this.option.ValueType;
+            set
+            {
+                if (this.option.ValueType != value)
+                {
+                    this.option.ValueType = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string CheckedValue
+        {
+            get => this.option.CheckedValue;
+            set
+            {
+                if (this.option.CheckedValue != value)
+                {
+                    this.option.CheckedValue = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string UncheckedValue
+        {
+            get => this.option.UncheckedValue;
+            set
+            {
+                if (this.option.UncheckedValue != value)
+                {
+                    this.option.UncheckedValue = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Group
+        {
+            get => this.option.Group;
+            set
+            {
+                if (this.option.Group != value)
+                {
+                    this.option.Group = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Category
+        {
+            get => this.option.Category;
+            set
+            {
+                if (this.option.Category != value)
+                {
+                    this.option.Category = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string ResourceKey
+        {
+            get => this.option.ResourceKey;
+            set
+            {
+                if (this.option.ResourceKey != value)
+                {
+                    this.option.ResourceKey = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Condition
+        {
+            get => this.option.Condition;
+            set
+            {
+                if (this.option.Condition != value)
+                {
+                    this.option.Condition = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string DefaultValue
+        {
+            get => this.option.DefaultValue;
+            set
+            {
+                if (this.option.DefaultValue != value)
+                {
+                    this.option.DefaultValue = value;
+                    this.OnPropertyChanged();
+                }
+            }
+        }
+
+        public string ItemsText
+        {
+            get
+            {
+                if (this.option.Items == null || this.option.Items.Count == 0) return string.Empty;
+                return string.Join(";", this.option.Items.Select(i => i.Text + ":" + i.Value));
+            }
+            set
+            {
+                var list = new List<CustomConverterOptionEntry>();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    foreach (var entry in value.Split(';'))
+                    {
+                        var parts = entry.Split(':');
+                        if (parts.Length > 0)
+                        {
+                            list.Add(new CustomConverterOptionEntry { Text = parts[0].Trim(), Value = parts.Length > 1 ? parts[1].Trim() : parts[0].Trim() });
+                        }
+                    }
+                }
+                this.option.Items = list;
+                this.OnPropertyChanged();
+            }
+        }
+    }
+}

--- a/Application/FileConverter/ViewModels/ManageCustomConvertersViewModel.cs
+++ b/Application/FileConverter/ViewModels/ManageCustomConvertersViewModel.cs
@@ -1,0 +1,111 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FileConverter.CustomConverters;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using Microsoft.Win32;
+
+namespace FileConverter.ViewModels
+{
+    public class ManageCustomConvertersViewModel : ObservableObject
+    {
+        private CustomConverterDefinition selected;
+
+        public ManageCustomConvertersViewModel()
+        {
+            this.Converters = new ObservableCollection<CustomConverterDefinition>(CustomConverterManager.Converters);
+            CustomConverterManager.ConvertersUpdated += () =>
+            {
+                this.Converters = new ObservableCollection<CustomConverterDefinition>(CustomConverterManager.Converters);
+                this.OnPropertyChanged(nameof(this.Converters));
+            };
+            this.removeCommand = new RelayCommand(this.RemoveSelected, () => this.Selected != null);
+            this.editCommand = new RelayCommand(this.EditSelected, () => this.Selected != null);
+            this.importCommand = new RelayCommand(this.ImportConverter);
+            this.exportCommand = new RelayCommand(this.ExportSelected, () => this.Selected != null);
+        }
+
+        public ObservableCollection<CustomConverterDefinition> Converters { get; private set; }
+
+        public CustomConverterDefinition Selected
+        {
+            get => this.selected;
+            set
+            {
+                if (this.SetProperty(ref this.selected, value))
+                {
+                    (this.RemoveCommand as RelayCommand)?.NotifyCanExecuteChanged();
+                    (this.EditCommand as RelayCommand)?.NotifyCanExecuteChanged();
+                    (this.ExportCommand as RelayCommand)?.NotifyCanExecuteChanged();
+                }
+            }
+        }
+
+        private readonly RelayCommand removeCommand;
+        public ICommand RemoveCommand => this.removeCommand;
+        private readonly RelayCommand editCommand;
+        public ICommand EditCommand => this.editCommand;
+        private readonly RelayCommand importCommand;
+        public ICommand ImportCommand => this.importCommand;
+        private readonly RelayCommand exportCommand;
+        public ICommand ExportCommand => this.exportCommand;
+
+        private void RemoveSelected()
+        {
+            if (this.Selected == null) return;
+            CustomConverterManager.RemoveConverter(this.Selected.Name);
+            this.Converters.Remove(this.Selected);
+        }
+
+        private void EditSelected()
+        {
+            if (this.Selected == null) return;
+            var vm = new CustomConverterWizardViewModel();
+            vm.Name = this.Selected.Name;
+            vm.ExtensionsText = string.Join(",", this.Selected.Extensions);
+            vm.OutputExtension = this.Selected.OutputExtension;
+            vm.ProgramPath = this.Selected.ProgramPath;
+            vm.Arguments = this.Selected.Arguments;
+            vm.OutputTemplate = this.Selected.OutputTemplate;
+            vm.IconPath = this.Selected.IconPath;
+            vm.PostProcessCommand = this.Selected.PostProcessCommand;
+            vm.MultiFileAtOnce = this.Selected.MultiFileAtOnce;
+            vm.ShowProgram = this.Selected.ShowProgram;
+            vm.PostAction = this.Selected.PostAction;
+            foreach (var opt in this.Selected.Options)
+            {
+                vm.Options.Add(opt);
+            }
+            var wnd = new Views.CustomConverterWizard { DataContext = vm };
+            if (wnd.ShowDialog() == true)
+            {
+                CustomConverterManager.SaveConverter(vm.Definition);
+                int index = this.Converters.IndexOf(this.Selected);
+                this.Converters[index] = vm.Definition;
+                this.Selected = vm.Definition;
+            }
+        }
+
+        private void ImportConverter()
+        {
+            var dlg = new Microsoft.Win32.OpenFileDialog { Filter = "Converter package (*.zip)|*.zip" };
+            if (dlg.ShowDialog() == true)
+            {
+                CustomConverterManager.Import(dlg.FileName);
+                this.Converters = new ObservableCollection<CustomConverterDefinition>(CustomConverterManager.Converters);
+                this.OnPropertyChanged(nameof(this.Converters));
+            }
+        }
+
+        private void ExportSelected()
+        {
+            if (this.Selected == null) return;
+            var dlg = new Microsoft.Win32.SaveFileDialog { Filter = "Converter package (*.zip)|*.zip", FileName = this.Selected.Name + ".zip" };
+            if (dlg.ShowDialog() == true)
+            {
+                CustomConverterManager.Export(this.Selected.Name, dlg.FileName);
+            }
+        }
+    }
+}

--- a/Application/FileConverter/ViewModels/SettingsViewModel.cs
+++ b/Application/FileConverter/ViewModels/SettingsViewModel.cs
@@ -9,6 +9,7 @@ namespace FileConverter.ViewModels
     using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
+    using System.Reflection;
     using System.Windows.Data;
     using System.Windows.Input;
 
@@ -21,6 +22,7 @@ namespace FileConverter.ViewModels
     using FileConverter.Annotations;
     using FileConverter.Services;
     using FileConverter.Views;
+    using FileConverter.CustomConverters;
 
     /// <summary>
     /// This class contains properties that the settings View can data bind to.
@@ -38,6 +40,8 @@ namespace FileConverter.ViewModels
         private RelayCommand getChangeLogContentCommand;
         private RelayCommand createFolderCommand;
         private RelayCommand newPresetCommand;
+        private RelayCommand addCustomConverterCommand;
+        private RelayCommand manageCustomConvertersCommand;
         private RelayCommand duplicatePresetCommand;
         private RelayCommand importPresetCommand;
         private RelayCommand exportPresetCommand;
@@ -61,6 +65,8 @@ namespace FileConverter.ViewModels
             this.openUrlCommand = new RelayCommand<string>((url) => Process.Start(url));
             this.createFolderCommand = new RelayCommand(this.CreateFolder);
             this.newPresetCommand = new RelayCommand(() => this.AddNewPreset(false));
+            this.addCustomConverterCommand = new RelayCommand(this.AddCustomConverter);
+            this.manageCustomConvertersCommand = new RelayCommand(this.ManageCustomConverters);
             this.duplicatePresetCommand = new RelayCommand(() => this.AddNewPreset(true), this.CanDuplicateSelectedPreset);
             this.importPresetCommand = new RelayCommand(this.ImportPreset);
             this.exportPresetCommand = new RelayCommand(this.ExportSelectedPreset, this.CanExportSelectedPreset);
@@ -88,6 +94,7 @@ namespace FileConverter.ViewModels
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Ico));
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Gif));
             outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Pdf));
+            outputTypeViewModels.Add(new OutputTypeViewModel(OutputType.Custom));
             this.outputTypes = new ListCollectionView(outputTypeViewModels);
             this.outputTypes.GroupDescriptions.Add(new PropertyGroupDescription("Category"));
 
@@ -275,6 +282,9 @@ namespace FileConverter.ViewModels
         public ICommand CreateFolderCommand => this.createFolderCommand;
 
         public ICommand AddNewPresetCommand => this.newPresetCommand;
+
+        public ICommand AddCustomConverterCommand => this.addCustomConverterCommand;
+        public ICommand ManageCustomConvertersCommand => this.manageCustomConvertersCommand;
 
         public ICommand DuplicatePresetCommand => this.duplicatePresetCommand;
 
@@ -590,6 +600,56 @@ namespace FileConverter.ViewModels
             this.saveCommand.NotifyCanExecuteChanged();
         }
 
+        private void AddCustomConverter()
+        {
+            var wizard = new Views.CustomConverterWizard()
+            {
+                DataContext = new CustomConverterWizardViewModel()
+            };
+
+            if (wizard.ShowDialog() == true && wizard.DataContext is CustomConverterWizardViewModel vm)
+            {
+                var def = vm.Definition;
+                string directory = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "CustomConverters");
+                System.IO.Directory.CreateDirectory(directory);
+                string filePath = System.IO.Path.Combine(directory, def.Name + ".xml");
+                XmlHelpers.SaveToFile("CustomConverter", filePath, def);
+
+                PresetFolderNode parent = this.SelectedFolder ?? this.presetsRootFolder;
+                int insertIndex = parent.Children.IndexOf(this.SelectedItem) + 1;
+                if (insertIndex < 0)
+                {
+                    insertIndex = parent.Children.Count;
+                }
+
+                var preset = new ConversionPreset(def.Name, OutputType.Custom, def.Extensions);
+                preset.CustomConverterName = def.Name;
+                preset.InputPostConversionAction = def.PostAction;
+                preset.OutputFileNameTemplate = def.OutputTemplate;
+                foreach (var opt in def.Options)
+                {
+                    string defaultValue = opt.DefaultValue;
+                    if (string.IsNullOrEmpty(defaultValue) && opt.Items.Count > 0)
+                    {
+                        defaultValue = opt.Items[0].Value;
+                    }
+                    preset.InitializeSettingsValue(opt.Name, defaultValue ?? string.Empty, true);
+                }
+
+                PresetNode node = new PresetNode(preset, parent);
+                parent.Children.Insert(insertIndex, node);
+                node.PropertyChanged += this.NodePropertyChanged;
+                this.SelectedItem = node;
+                this.OnPresetCreated?.Invoke();
+        }
+
+        private void ManageCustomConverters()
+        {
+            var vm = new ManageCustomConvertersViewModel();
+            var wnd = new Views.ManageCustomConvertersWindow { DataContext = vm };
+            wnd.ShowDialog();
+        }
+        
         private void ImportPreset()
         {
             OpenFileDialog openFileDialog = new OpenFileDialog

--- a/Application/FileConverter/Views/CustomConverterWizard.xaml
+++ b/Application/FileConverter/Views/CustomConverterWizard.xaml
@@ -1,0 +1,77 @@
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:FileConverter"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:generic="clr-namespace:FileConverter.ValueConverters.Generic"
+        x:Class="FileConverter.Views.CustomConverterWizard"
+        Title="New Custom Converter" Height="400" Width="500" WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <ObjectDataProvider x:Key="PostActions" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="local:InputPostConversionAction" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+        <generic:EqualsConverter x:Key="EqualsConverter" />
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel Margin="10" Visibility="{Binding StepIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=0}">
+            <TextBlock Text="Step 1" FontWeight="Bold" Margin="0,0,0,10"/>
+            <TextBlock Text="Name"/>
+            <TextBox Text="{Binding Name}" Margin="0,0,0,5"/>
+            <TextBlock Text="Input extensions (comma separated)"/>
+            <TextBox Text="{Binding ExtensionsText}" Margin="0,0,0,5"/>
+            <TextBlock Text="Output extension"/>
+            <TextBox Text="{Binding OutputExtension}" Margin="0,0,0,5"/>
+        </StackPanel>
+        <StackPanel Margin="10" Visibility="{Binding StepIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=1}">
+            <TextBlock Text="Step 2" FontWeight="Bold" Margin="0,0,0,10"/>
+            <TextBlock Text="Program path"/>
+            <TextBox Text="{Binding ProgramPath}" Margin="0,0,0,5"/>
+            <TextBlock Text="Arguments"/>
+            <TextBox Text="{Binding Arguments}" Margin="0,0,0,5"/>
+            <CheckBox Content="Multi file at once" IsChecked="{Binding MultiFileAtOnce}" Margin="0,0,0,5"/>
+            <CheckBox Content="Show program" IsChecked="{Binding ShowProgram}" Margin="0,0,0,5"/>
+            <TextBlock Text="Post action"/>
+            <ComboBox ItemsSource="{Binding Source={StaticResource PostActions}}" SelectedItem="{Binding PostAction}" Margin="0,0,0,5"/>
+            <TextBlock Text="Output template"/>
+            <TextBox Text="{Binding OutputTemplate}" Margin="0,0,0,5"/>
+            <TextBlock Text="Icon path"/>
+            <TextBox Text="{Binding IconPath}" Margin="0,0,0,5"/>
+            <Image Width="32" Height="32" Source="{Binding IconPath}" Margin="0,0,0,5"/>
+            <TextBlock Text="Post process command"/>
+            <TextBox Text="{Binding PostProcessCommand}" Margin="0,0,0,5"/>
+        </StackPanel>
+        <StackPanel Margin="10" Visibility="{Binding StepIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=2}">
+            <TextBlock Text="Step 3" FontWeight="Bold" Margin="0,0,0,10"/>
+            <Button Content="Add option" Width="100" Margin="0,0,0,5" Command="{Binding AddOptionCommand}"/>
+            <Button Content="Edit option" Width="100" Margin="0,0,0,5" Command="{Binding EditOptionCommand}"/>
+            <DataGrid x:Name="OptionsGrid" AutoGenerateColumns="False" Height="200" Margin="0,5,0,0" SelectedItem="{Binding SelectedOption}">
+                <DataGrid.ItemsSource>
+                    <CollectionViewSource Source="{Binding Options}" IsLiveGroupingRequested="True">
+                        <CollectionViewSource.GroupDescriptions>
+                            <PropertyGroupDescription PropertyName="Category" />
+                        </CollectionViewSource.GroupDescriptions>
+                    </CollectionViewSource>
+                </DataGrid.ItemsSource>
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Name" Binding="{Binding DisplayName}" />
+                    <DataGridTextColumn Header="Control" Binding="{Binding ControlType}" />
+                    <DataGridTextColumn Header="Default" Binding="{Binding DefaultValue}" />
+                    <DataGridTextColumn Header="Category" Binding="{Binding Category}" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <Button Content="Remove option" Width="100" Margin="0,5,0,0" Command="{Binding RemoveOptionCommand}"/>
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="10">
+            <Button Content="Back" Width="80" Margin="5" Command="{Binding BackCommand}"/>
+            <Button Content="Next" Width="80" Margin="5" Command="{Binding NextCommand}" Visibility="{Binding StepIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=0}"/>
+            <Button Content="Next" Width="80" Margin="5" Command="{Binding NextCommand}" Visibility="{Binding StepIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=1}"/>
+            <Button Content="Finish" Width="80" Margin="5" Command="{Binding FinishCommand}" Visibility="{Binding StepIndex, Converter={StaticResource EqualsConverter}, ConverterParameter=2}"/>
+            <Button Content="Cancel" Width="80" Margin="5" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Application/FileConverter/Views/CustomConverterWizard.xaml.cs
+++ b/Application/FileConverter/Views/CustomConverterWizard.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace FileConverter.Views
+{
+    public partial class CustomConverterWizard : Window
+    {
+        public CustomConverterWizard()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Application/FileConverter/Views/CustomOptionEditor.xaml
+++ b/Application/FileConverter/Views/CustomOptionEditor.xaml
@@ -1,0 +1,49 @@
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="FileConverter.Views.CustomOptionEditor"
+        Title="Option" Height="400" Width="400" WindowStartupLocation="CenterOwner">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <StackPanel>
+            <TextBlock Text="Element name" />
+            <TextBox Text="{Binding ElementName}" Margin="0,0,0,5" />
+            <TextBlock Text="Name" />
+            <TextBox Text="{Binding Name}" Margin="0,0,0,5" />
+            <TextBlock Text="Control type" />
+            <ComboBox SelectedItem="{Binding ControlType}" Margin="0,0,0,5">
+                <ComboBoxItem>dropdown</ComboBoxItem>
+                <ComboBoxItem>slider</ComboBoxItem>
+                <ComboBoxItem>textbox</ComboBoxItem>
+                <ComboBoxItem>checkbox</ComboBoxItem>
+                <ComboBoxItem>radio</ComboBoxItem>
+            </ComboBox>
+            <TextBlock Text="Scale" />
+            <TextBox Text="{Binding Scale}" Margin="0,0,0,5" />
+            <TextBlock Text="Value type" />
+            <TextBox Text="{Binding ValueType}" Margin="0,0,0,5" />
+            <TextBlock Text="Checked value" />
+            <TextBox Text="{Binding CheckedValue}" Margin="0,0,0,5" />
+            <TextBlock Text="Unchecked value" />
+            <TextBox Text="{Binding UncheckedValue}" Margin="0,0,0,5" />
+            <TextBlock Text="Group" />
+            <TextBox Text="{Binding Group}" Margin="0,0,0,5" />
+            <TextBlock Text="Default value" />
+            <TextBox Text="{Binding DefaultValue}" Margin="0,0,0,5" />
+            <TextBlock Text="Category" />
+            <TextBox Text="{Binding Category}" Margin="0,0,0,5" />
+            <TextBlock Text="Resource key" />
+            <TextBox Text="{Binding ResourceKey}" Margin="0,0,0,5" />
+            <TextBlock Text="Condition" />
+            <TextBox Text="{Binding Condition}" Margin="0,0,0,5" />
+            <TextBlock Text="Items (text:value;...)" />
+            <TextBox Text="{Binding ItemsText}" Margin="0,0,0,5" />
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="80" Margin="5" Command="{Binding OkCommand}"/>
+            <Button Content="Cancel" Width="80" Margin="5" IsCancel="True" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Application/FileConverter/Views/CustomOptionEditor.xaml.cs
+++ b/Application/FileConverter/Views/CustomOptionEditor.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace FileConverter.Views
+{
+    public partial class CustomOptionEditor : Window
+    {
+        public CustomOptionEditor()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/Application/FileConverter/Views/ManageCustomConvertersWindow.xaml
+++ b/Application/FileConverter/Views/ManageCustomConvertersWindow.xaml
@@ -1,0 +1,28 @@
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="FileConverter.Views.ManageCustomConvertersWindow"
+        Title="Custom Converters" Height="400" Width="500" WindowStartupLocation="CenterOwner">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ListBox ItemsSource="{Binding Converters}" SelectedItem="{Binding Selected}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal">
+                        <Image Width="16" Height="16" Margin="0,0,5,0" Source="{Binding IconAbsolutePath}"/>
+                        <TextBlock Text="{Binding Name}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Edit" Width="70" Margin="5" Command="{Binding EditCommand}"/>
+            <Button Content="Remove" Width="70" Margin="5" Command="{Binding RemoveCommand}"/>
+            <Button Content="Import" Width="70" Margin="5" Command="{Binding ImportCommand}"/>
+            <Button Content="Export" Width="70" Margin="5" Command="{Binding ExportCommand}"/>
+            <Button Content="Close" Width="70" Margin="5" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Application/FileConverter/Views/ManageCustomConvertersWindow.xaml.cs
+++ b/Application/FileConverter/Views/ManageCustomConvertersWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace FileConverter.Views
+{
+    public partial class ManageCustomConvertersWindow : Window
+    {
+        public ManageCustomConvertersWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/Application/FileConverter/Views/Resources/ConversionPresetTemplates.xaml
+++ b/Application/FileConverter/Views/Resources/ConversionPresetTemplates.xaml
@@ -4,6 +4,7 @@
                     xmlns:valueConverters="clr-namespace:FileConverter.ValueConverters"
                     xmlns:project="clr-namespace:FileConverter.Properties"
                     xmlns:controls="clr-namespace:FileConverter.Controls"
+                    xmlns:converters="clr-namespace:FileConverter.CustomConverters"
                     xmlns:globalization="clr-namespace:System.Globalization;assembly=mscorlib"
                     xmlns:views="clr-namespace:FileConverter.Views"
                     xmlns:fileConverter="clr-namespace:FileConverter"
@@ -21,6 +22,8 @@
     <valueConverters:OutputTypeEnumToViewModel x:Key="OutputTypeEnumToViewModel"/>
     <valueConverters:ConversionSettingsRelevant x:Key="ConversionSettingsRelevant"/>
     <valueConverters:HardwareAccelerationModeToString x:Key="HardwareAccelerationModeToString"/>
+    <valueConverters:CustomOptionValueConverter x:Key="CustomOptionValueConverter"/>
+    <valueConverters:OptionVisibilityConverter x:Key="OptionVisibilityConverter"/>
 
     <generic:ValueConverterGroup x:Key="ConversionSettingsToEnum">
         <valueConverters:ConversionSettingsToString/>
@@ -660,6 +663,9 @@
             <DataTrigger Binding="{Binding OutputType}" Value="Webp">
                 <Setter Property="ContentTemplate" Value="{StaticResource JpgSettingsDataTemplate}"/>
             </DataTrigger>
+            <DataTrigger Binding="{Binding OutputType}" Value="Custom">
+                <Setter Property="ContentTemplate" Value="{StaticResource CustomConverterSettingsDataTemplate}"/>
+            </DataTrigger>
         </Style.Triggers>
     </Style>
 
@@ -708,6 +714,63 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+
+    <DataTemplate x:Key="CustomConverterOptionTemplate" DataType="{x:Type converters:CustomConverterOptionDefinition}">
+        <StackPanel Margin="0,5">
+            <StackPanel.Visibility>
+                <MultiBinding Converter="{StaticResource OptionVisibilityConverter}">
+                    <Binding />
+                    <Binding RelativeSource="{RelativeSource AncestorType=ItemsControl}" Path="DataContext" />
+                </MultiBinding>
+            </StackPanel.Visibility>
+            <TextBlock x:Name="Label" Text="{Binding DisplayName}" />
+            <ComboBox x:Name="Dropdown" Visibility="Collapsed" ItemsSource="{Binding Items}" SelectedValuePath="Value"
+                      SelectedValue="{Binding DataContext.Settings, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource CustomOptionValueConverter}, ConverterParameter={Binding}}"/>
+            <Slider x:Name="Slider" Visibility="Collapsed" Minimum="0" Maximum="{Binding Scale, Converter={StaticResource StringToValueType}, ConverterParameter=System.Double}"
+                    Value="{Binding DataContext.Settings, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource CustomOptionValueConverter}, ConverterParameter={Binding}}"/>
+            <TextBox x:Name="TextBox" Visibility="Collapsed" Text="{Binding DataContext.Settings, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource CustomOptionValueConverter}, ConverterParameter={Binding}}"/>
+            <CheckBox x:Name="Check" Visibility="Collapsed" Content="{Binding DisplayName}"
+                      IsChecked="{Binding DataContext.Settings, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource CustomOptionValueConverter}, ConverterParameter={Binding}}"/>
+            <RadioButton x:Name="Radio" Visibility="Collapsed" Content="{Binding DisplayName}" GroupName="{Binding Group}"
+                        IsChecked="{Binding DataContext.Settings, RelativeSource={RelativeSource AncestorType=ItemsControl}, Converter={StaticResource CustomOptionValueConverter}, ConverterParameter={Binding}}"/>
+        </StackPanel>
+        <DataTemplate.Triggers>
+            <DataTrigger Binding="{Binding ControlType}" Value="dropdown">
+                <Setter TargetName="Dropdown" Property="Visibility" Value="Visible"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ControlType}" Value="slider">
+                <Setter TargetName="Slider" Property="Visibility" Value="Visible"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ControlType}" Value="textbox">
+                <Setter TargetName="TextBox" Property="Visibility" Value="Visible"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ControlType}" Value="checkbox">
+                <Setter TargetName="Check" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="Label" Property="Visibility" Value="Collapsed"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ControlType}" Value="radio">
+                <Setter TargetName="Radio" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="Label" Property="Visibility" Value="Collapsed"/>
+            </DataTrigger>
+        </DataTemplate.Triggers>
+    </DataTemplate>
+
+    <DataTemplate x:Key="CustomConverterSettingsDataTemplate" DataType="{x:Type fileConverter:ConversionPreset}">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <ItemsControl>
+                <ItemsControl.ItemsSource>
+                    <CollectionViewSource Source="{Binding CustomConverterDefinition.Options}" IsLiveGroupingRequested="True">
+                        <CollectionViewSource.GroupDescriptions>
+                            <PropertyGroupDescription PropertyName="Category" />
+                        </CollectionViewSource.GroupDescriptions>
+                    </CollectionViewSource>
+                </ItemsControl.ItemsSource>
+                <ItemsControl.ItemTemplate>
+                    <StaticResource ResourceKey="CustomConverterOptionTemplate" />
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </DataTemplate>
 
 </ResourceDictionary>
     

--- a/Application/FileConverter/Views/SettingsWindow.xaml
+++ b/Application/FileConverter/Views/SettingsWindow.xaml
@@ -305,10 +305,17 @@
                                     </MenuItem>
                                     <MenuItem Header="{x:Static project:Resources.AddNewPreset}" Command="{Binding AddNewPresetCommand}">
                                         <MenuItem.Icon>
-                                            <Image Source="{Binding Source=/FileConverter;component/Resources/PresetIcon.ico, Converter={StaticResource IcoFileSizeSelector}, ConverterParameter=48}" 
+                                            <Image Source="{Binding Source=/FileConverter;component/Resources/PresetIcon.ico, Converter={StaticResource IcoFileSizeSelector}, ConverterParameter=48}"
                                                    Style="{StaticResource EnableDisableImageStyle}"/>
                                         </MenuItem.Icon>
                                     </MenuItem>
+                                    <MenuItem Header="{x:Static project:Resources.AddCustomConverter}" Command="{Binding AddCustomConverterCommand}">
+                                        <MenuItem.Icon>
+                                            <Image Source="{Binding Source=/FileConverter;component/Resources/PresetIcon.ico, Converter={StaticResource IcoFileSizeSelector}, ConverterParameter=48}"
+                                                   Style="{StaticResource EnableDisableImageStyle}"/>
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Header="{x:Static project:Resources.ManageCustomConverters}" Command="{Binding ManageCustomConvertersCommand}"/>
                                     <MenuItem Header="{x:Static project:Resources.DuplicatePreset}" Command="{Binding DuplicatePresetCommand}">
                                         <MenuItem.Icon>
                                             <Image Source="{Binding Source=/FileConverter;component/Resources/DuplicatePresetIcon.ico, Converter={StaticResource IcoFileSizeSelector}, ConverterParameter=48}" 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ If you encounter any problem with File Converter, you can:
 * See the already known problems in the [troubleshooting section of the documentation](https://github.com/Tichau/FileConverter/wiki/Troubleshooting).
 * Or report an issue on the [bug tracker](https://github.com/Tichau/FileConverter/issues).
 
+## Custom converters
+
+File Converter can load additional conversion presets from XML files placed in
+the `CustomConverters` folder next to the application. These definitions let you
+configure:
+
+* Supported input extensions and the output extension
+* The external program to run and its command line arguments
+* Optional variables and options that appear in the preset editor
+* Output filename templates, icons and post-processing commands
+
+See `Application/FileConverter/CustomConverters/sample.xml` for an example.
+
 ## Setup development environment
 
 ### Requirements


### PR DESCRIPTION
## Summary
- enable editing converter option properties correctly
- provide GUI wizard for defining custom converters and option attributes
- support output templates, icons, categories, post-processing and localization for converters
- display custom converter option UI when editing presets
- capture output when running external converters for better error reporting
- hide or show custom converter options based on preset values
- document custom converter functionality

## Testing
- ❌ `dotnet build Application/FileConverter/FileConverter.csproj -clp:ErrorsOnly` (failed to run: `dotnet` not found)


------
https://chatgpt.com/codex/tasks/task_e_6854930fa1408330bdb46723278137cd