### PR TITLE
Fix TreeView build errors

### DIFF
--- a/Application/FileConverter/CustomConverters/CustomConverterManager.cs
+++ b/Application/FileConverter/CustomConverters/CustomConverterManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Reflection;
 
 namespace FileConverter.CustomConverters
@@ -176,7 +177,22 @@ namespace FileConverter.CustomConverters
         {
             string directory = GetDirectory();
             Directory.CreateDirectory(directory);
-            System.IO.Compression.ZipFile.ExtractToDirectory(package, directory, true);
+
+            using (ZipArchive zip = ZipFile.OpenRead(package))
+            {
+                foreach (ZipArchiveEntry entry in zip.Entries)
+                {
+                    string destinationPath = Path.Combine(directory, entry.FullName);
+                    string fullPath = Path.GetFullPath(destinationPath);
+                    if (!fullPath.StartsWith(directory, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                    Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+                    entry.ExtractToFile(fullPath, true);
+                }
+            }
+
             converters = null;
             ConvertersUpdated?.Invoke();
         }

--- a/Application/FileConverter/PathHelpers.cs
+++ b/Application/FileConverter/PathHelpers.cs
@@ -214,5 +214,28 @@ namespace FileConverter
 
             return outputPath;
         }
+
+        public static string GetRelativePath(string baseDirectory, string filePath)
+        {
+            if (string.IsNullOrEmpty(baseDirectory) || string.IsNullOrEmpty(filePath))
+            {
+                return filePath;
+            }
+
+            Uri baseUri = new Uri(AppendDirectorySeparator(baseDirectory));
+            Uri fileUri = new Uri(filePath);
+            Uri relativeUri = baseUri.MakeRelativeUri(fileUri);
+            string relative = Uri.UnescapeDataString(relativeUri.ToString());
+            return relative.Replace('/', System.IO.Path.DirectorySeparatorChar);
+        }
+
+        private static string AppendDirectorySeparator(string path)
+        {
+            if (!path.EndsWith(System.IO.Path.DirectorySeparatorChar.ToString()))
+            {
+                return path + System.IO.Path.DirectorySeparatorChar;
+            }
+            return path;
+        }
     }
 }

--- a/Application/FileConverter/ViewModels/ManageCustomConvertersViewModel.cs
+++ b/Application/FileConverter/ViewModels/ManageCustomConvertersViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using FileConverter.CustomConverters;
 using FileConverter.Services;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
@@ -110,7 +111,7 @@ namespace FileConverter.ViewModels
             string baseDir = CustomConverterManager.GetDirectory();
             foreach (var def in this.Converters)
             {
-                string relative = string.IsNullOrEmpty(def.FilePath) ? def.Name + ".xml" : System.IO.Path.GetRelativePath(baseDir, def.FilePath);
+                string relative = string.IsNullOrEmpty(def.FilePath) ? def.Name + ".xml" : FileConverter.PathHelpers.GetRelativePath(baseDir, def.FilePath);
                 var parts = relative.Split(System.IO.Path.DirectorySeparatorChar);
                 CustomConverterFolder folder = root;
                 for (int i = 0; i < parts.Length - 1; i++)
@@ -226,9 +227,11 @@ namespace FileConverter.ViewModels
                 else
                 {
                     var serializer = new XmlSerializer(typeof(CustomConverterDefinition), new XmlRootAttribute("CustomConverter"));
-                    using StringWriter sw = new StringWriter();
-                    serializer.Serialize(sw, this.Selected);
-                    this.XmlText = sw.ToString();
+                    using (StringWriter sw = new StringWriter())
+                    {
+                        serializer.Serialize(sw, this.Selected);
+                        this.XmlText = sw.ToString();
+                    }
                 }
             }
             catch (Exception ex)
@@ -247,8 +250,11 @@ namespace FileConverter.ViewModels
             try
             {
                 var serializer = new XmlSerializer(typeof(CustomConverterDefinition), new XmlRootAttribute("CustomConverter"));
-                using StringReader sr = new StringReader(this.XmlText ?? string.Empty);
-                var def = (CustomConverterDefinition)serializer.Deserialize(sr);
+                CustomConverterDefinition def;
+                using (StringReader sr = new StringReader(this.XmlText ?? string.Empty))
+                {
+                    def = (CustomConverterDefinition)serializer.Deserialize(sr);
+                }
                 CustomConverterManager.SaveConverter(def);
                 int index = this.Converters.IndexOf(this.Selected);
                 if (index >= 0)

--- a/Application/FileConverter/ViewModels/SettingsViewModel.cs
+++ b/Application/FileConverter/ViewModels/SettingsViewModel.cs
@@ -12,6 +12,7 @@ namespace FileConverter.ViewModels
     using System.Reflection;
     using System.Windows.Data;
     using System.Windows.Input;
+    using System.Windows;
 
     using Microsoft.Win32;
     

--- a/Application/FileConverter/Views/SettingsWindow.xaml
+++ b/Application/FileConverter/Views/SettingsWindow.xaml
@@ -375,7 +375,7 @@
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <TreeView Grid.Row="0" ItemsSource="{Binding RootFolder.Children}" SelectedItem="{Binding SelectedItem}">
+                    <TreeView Grid.Row="0" ItemsSource="{Binding RootFolder.Children}">
                         <TreeView.Resources>
                             <HierarchicalDataTemplate DataType="{x:Type viewModels:CustomConverterFolder}" ItemsSource="{Binding Children}">
                                 <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
@@ -387,6 +387,9 @@
                                 </StackPanel>
                             </DataTemplate>
                         </TreeView.Resources>
+                        <behaviors:Interaction.Behaviors>
+                            <views:TreeViewSelectionBehavior SelectedItem="{Binding SelectedItem, Mode=TwoWay}" ExpandSelected="False"/>
+                        </behaviors:Interaction.Behaviors>
                     </TreeView>
 
                     <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">


### PR DESCRIPTION
## Summary
- support relative path calculation for .NET Framework
- fix CustomConverters import/export compilation issues
- replace C# 8 `using` declarations with old-style statements
- reference MessageBox properly

## Testing
- `dotnet build FileConverter.sln -c Release` *(fails: Installer.sign missing and System.Resources.Extensions not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856eba1e60883309ddfca1f54088abb